### PR TITLE
Validate that the host is valid

### DIFF
--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -3,7 +3,6 @@
 namespace DomainValidity\Host;
 
 use DomainValidity\Parse\HostParser;
-use InvalidArgumentException;
 
 class Host
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -23,3 +23,9 @@ function remove_empty_lines(string $text): ?string
 
     return $text;
 }
+
+function validate_domain_root(string $root): bool
+{
+    // Check if the string only contains alphanumeric values, dots or dashes
+    return preg_match('/^[a-zA-Z0-9.-]+$/', $root) === 1;
+}

--- a/tests/Unit/ValidatorTest.php
+++ b/tests/Unit/ValidatorTest.php
@@ -52,3 +52,13 @@ describe('Invalid adro.is.a.rocker.and', function () {
     it('empty domain', fn () =>  expect($host->domain())->toBe(''));
     it("is same as $url", fn () =>  expect($host->original())->toBe($url));
 });
+
+describe('Invalid *.adro.com', function () {
+    $validator = getInstance();
+    $url = 'https://*.adro.com';
+    $host = $validator->validate($url);
+
+    it('is not a valid domain', fn () =>  expect($host->isValid())->toBeFalse());
+    it('is not empty domain', fn () =>  expect($host->domain())->toBe('adro.com'));
+    it("is same as $url", fn () =>  expect($host->original())->toBe($url));
+});


### PR DESCRIPTION
This is to preven't hosts like `*.adro.com` to validate as the `*` is not a valid character.